### PR TITLE
Fixes and reorder of installation page

### DIFF
--- a/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
+++ b/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
@@ -21,7 +21,9 @@ Your Anypoint Service Mesh installation requires the following applications and 
 ** Google Kubernetes Engine (GKE)
 ** Amazon EKS
 ** Azure Kubernetes Service (AKS)
-* Install Istio with policy enforcement and telemetry enabled. For more information about how to install Istio with this configuration enabled, see <<install_Istio,Installing Istio>>.
+* Install Istio with policy enforcement and telemetry enabled. 
++
+For more information about how to install Istio with this configuration enabled, see <<install_Istio,Installing Istio>>.
 
 == Hardware Requirements
 
@@ -152,11 +154,10 @@ spec:
       v2:
         enabled: false
 ----  
-When using the full manifest, ensure that you choose the correct profile. In the example, the `default` profile is used. To install the manifest, execute:
+When using the full manifest, ensure that you choose the correct profile. In the example, the `default` profile is used. 
+To install the manifest, run:
 +
 `istioctl manifest apply -f <manifest-file.yaml>`
-+
-
 
 === Install Istio 1.4.x
 

--- a/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
+++ b/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
@@ -21,9 +21,7 @@ Your Anypoint Service Mesh installation requires the following applications and 
 ** Google Kubernetes Engine (GKE)
 ** Amazon EKS
 ** Azure Kubernetes Service (AKS)
-* Install Istio
-+
-For more information about how to install specific versions of Istio, see <<install_Istio,Installing Istio>>.
+* Install Istio with policy enforcement and telemetry enabled. For more information about how to install Istio with this configuration enabled, see <<install_Istio,Installing Istio>>.
 
 == Hardware Requirements
 
@@ -87,16 +85,6 @@ In your network, you might need to whitelist the hostnames and ports of external
 
 You can install Istio 1.4.x or 1.5.x in your environment to support Anypoint Service Mesh. However, the Istio configuration for Anypoint Service Mesh differs based on the Istio version that you installed.
 
-=== Install Istio 1.4.x
-
-To install and configure Istio 1.4.x for Anypoint Service Mesh:
-
-. Download Istio using the https://istio.io/docs/setup/[Istio Documentation].
-. Install Istio with the policy control flag enabled:
-+
-`--set values.global.disablePolicyChecks=false`
-+
-For more information about this flag, see https://archive.istio.io/v1.4/docs/tasks/policy-enforcement/enabling-policy/[Policy Enforcement].
 
 === Install Istio 1.5.x
 
@@ -164,8 +152,22 @@ spec:
       v2:
         enabled: false
 ----  
-When using the full manifest, ensure that you choose the correct profile. In the example, the `default` profile is used.
+When using the full manifest, ensure that you choose the correct profile. In the example, the `default` profile is used. To install the manifest, execute:
++
+`istioctl manifest apply -f <manifest-file.yaml>`
++
 
+
+=== Install Istio 1.4.x
+
+To install and configure Istio 1.4.x for Anypoint Service Mesh:
+
+. Download Istio using the https://istio.io/docs/setup/[Istio Documentation].
+. Install Istio with the policy control flag enabled:
++
+`--set values.global.disablePolicyChecks=false`
++
+For more information about this flag, see https://archive.istio.io/v1.4/docs/tasks/policy-enforcement/enabling-policy/[Policy Enforcement].
 
 == See Also
 


### PR DESCRIPTION
This PR makes the following changes:
- Clarify that user also needs to enable policy enforcement and telemetry on the prerequisites part
- Add instruction to install manifest. 
- Reorder to place istio 1.5.x before 1.4.x 