### PR TITLE
Add Overview index to main nav

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 .xref:index.adoc[Anypoint Service Mesh]
-//* xref:service-mesh-overview-and-landing-page.adoc[Overview]
+* xref:index.adoc[Overview]
 * xref:getting-started-service-mesh.adoc[Getting started with Service Mesh]
 * xref:prepare-to-install-service-mesh.adoc[Reviewing Prerequisites]
 * xref:download-and-install-service-mesh.adoc[Downloading and Installing Service Mesh]


### PR DESCRIPTION
This adds the main index page to the nav bar:
![Screen Shot 2020-04-30 at 2 03 25 AM](https://user-images.githubusercontent.com/16763154/80673940-e9252d80-8a86-11ea-8747-c4f573d7d095.png)

Otherwise, the index page is not accessible from the site.