### PR TITLE
Remove references to platformUri in adapter creation

### DIFF
--- a/modules/ROOT/pages/provision-adapter-configure-service-mesh-CLI.adoc
+++ b/modules/ROOT/pages/provision-adapter-configure-service-mesh-CLI.adoc
@@ -110,8 +110,7 @@ asmctl adapter create \
 --size=<adapter plan size> \
 --replicas=<amount of replicas for the adapter> \
 --clientId=<clientId of the environment or organization> \
---clientSecret=<client secret of the environment or organization> \
---platformUri=<URL of Anypoint Platform>
+--clientSecret=<client secret of the environment or organization>
 ----
 +
 [%header%autowidth.spread]

--- a/modules/ROOT/pages/provision-adapter-configure-service-mesh-CRD.adoc
+++ b/modules/ROOT/pages/provision-adapter-configure-service-mesh-CRD.adoc
@@ -72,7 +72,6 @@ spec:
   parameters:
     clientId: <client id> # example: 4bc55ee4cfc84a2ddddbb2c1109d1123c5c4
     clientSecret: <client secret> # example: 8E5ae17BbB664Eddd9ab32A5fA869874Be7
-    platformUri: <platform uri> # example: https://eu1.anypoint.mulesoft.com
     replication: 
       replicas: <amount of replicas> # example: 2
 ----


### PR DESCRIPTION
### Description

This PR removes remaining references to `platformUri` parameter in the adapter creation, that is not longer supported in that command.