### PR TITLE
Remove broken old link

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -50,7 +50,6 @@ The adapter then performs policy checks and verifications.
 
 == See Also
 
-* link:https://istio.io/docs/reference/config/policy-and-telemetry/mixer-overview/#adapters[Adapter Overview]
 * link:https://istio.io/docs/concepts/what-is-istio/[Istio Documentation]
 
 


### PR DESCRIPTION
This PR removes a link (which is broken) that should not appear in neither 1.1 or 1.2 docs. Once merged, this PR should be cherry-picked to branch `v1.1`.