### PR TITLE
Bump versions supported in ASM 1.2.x

### DIFF
--- a/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
+++ b/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
@@ -24,7 +24,7 @@ Your Anypoint Service Mesh installation requires the following applications and 
 ** Red Hat OpenShift
 * Kubernetes (versions 1.12 through 1.20) or Red Hat OpenShift (version 4.x)
 
-* <<install_Istio,Istio>> (currently supported versions include 1.7.x, 1.8.x and 1.9.x)
+* <<install_Istio,Istio>> (currently supported versions include 1.7.x, 1.8.x, and 1.9.x)
 
 == Hardware Requirements
 

--- a/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
+++ b/modules/ROOT/pages/prepare-to-install-service-mesh.adoc
@@ -22,9 +22,9 @@ Your Anypoint Service Mesh installation requires the following applications and 
 ** Amazon EKS
 ** Azure Kubernetes Service (AKS)
 ** Red Hat OpenShift
-* Kubernetes (versions 1.12 through 1.19) or Red Hat OpenShift (version 4.x)
+* Kubernetes (versions 1.12 through 1.20) or Red Hat OpenShift (version 4.x)
 
-* <<install_Istio,Istio>> (currently supported versions include 1.7.x and 1.8.x)
+* <<install_Istio,Istio>> (currently supported versions include 1.7.x, 1.8.x and 1.9.x)
 
 == Hardware Requirements
 


### PR DESCRIPTION
We will be releasing a minor patch version to our CLI to allow the installation using Kubernetes 1.20 and Istio 1.9.x, this PR adds both versions to the supported list