### PR TITLE
[W-11732939] callout + typos for v1.0

### DIFF
--- a/modules/ROOT/edits/service-mesh-overview-and-landing-page.adoc
+++ b/modules/ROOT/edits/service-mesh-overview-and-landing-page.adoc
@@ -37,7 +37,7 @@ image::anypoint-service-mesh-architecture.png[Anypoint Service Mesh Architecture
 
 As illustrated in the diagram, at the top of the architecture is Anypoint Platform, which brings complete lifecycle API management capabilities to the microservices built with Mule runtime engine (Mule). These Mule instances might be deployed within CloudHub, or Runtime Fabric at your location. 
 
-Istio, which is installed on a Kubernentes cluster, uses Envoy to manage the services using a sidecar proxy. The sidecar is responsible for any communication with the service, and resides within the same container as your service. With the Anypoint Service Mesh enabled, you can easily apply any of Istio’s native policies for traffic control and security. These policies help ensure reliable and secure service-to-service communication.
+Istio, which is installed on a Kubernetes cluster, uses Envoy to manage the services using a sidecar proxy. The sidecar is responsible for any communication with the service, and resides within the same container as your service. With the Anypoint Service Mesh enabled, you can easily apply any of Istio’s native policies for traffic control and security. These policies help ensure reliable and secure service-to-service communication.
 
 The MuleSoft adapter and broker, which reside within the Istio mixer, connect components to Anypoint Platform. The adapter and broker enable sharing of metadata about all the services that are managed by the mesh. This allows for discovery of your existing microservices from the Kubernetes cluster as APIs into Anypoint Platform. 
 
@@ -45,7 +45,7 @@ After the services are discovered, Anypoint Exchange uses the metadata to automa
 
 == Request Flow
 
-When a service is called, Anypoint Service Mesh ensures a smooth request flow and security checks as shown in the following diagam:
+When a service is called, Anypoint Service Mesh ensures a smooth request flow and security checks as shown in the following diagram:
 
 image:service-mesh-flows.jpeg[]
 

--- a/modules/ROOT/pages/bind-api-configure-service-mesh-CLI.adoc
+++ b/modules/ROOT/pages/bind-api-configure-service-mesh-CLI.adoc
@@ -92,7 +92,6 @@ image::api-manager-status-for-service-mesh.png[85%, 85%]
 . Service status.
 
 [[bind_using_ASM]]
-
 == Bind an API Created Using Anypoint Service Mesh
 
 To create the binding:

--- a/modules/ROOT/pages/bind-api-configure-service-mesh-CLI.adoc
+++ b/modules/ROOT/pages/bind-api-configure-service-mesh-CLI.adoc
@@ -43,10 +43,12 @@ To bind the service with an API, perform the following steps:
 +
 .The diagram shows the location where the API ID is displayed on the API version window.
 image::bind-api-id.png[Display API ID]
-+
-<1> API name and API instance version.
-<2> API ID.
-+
+
+[calloutlist]
+. API name and API instance version.
+. API ID.
+
+[start=4]
 . Retrieve from Kubernetes the name of the service with which you want to bind the API:
 +
 `kubectl get svc -n _namespace_`
@@ -84,9 +86,11 @@ After you bind your API, the API in API Manager is marked as Active. You are now
 +
 .The diagram shows the location where the status of the service is displayed.
 image::api-manager-status-for-service-mesh.png[85%, 85%]
-+
-<1> API name and API instance version.
-<2> Service status.
+
+[calloutlist]
+. API name and API instance version.
+. Service status.
+
 [[bind_using_ASM]]
 
 == Bind an API Created Using Anypoint Service Mesh

--- a/modules/ROOT/pages/bind-api-configure-service-mesh-CRD.adoc
+++ b/modules/ROOT/pages/bind-api-configure-service-mesh-CRD.adoc
@@ -45,10 +45,12 @@ Ensure that you save this API ID somewhere that you can access readily.
 +
 .The diagram shows the location where the API ID is displayed on the API version window.
 image::bind-api-id.png[Display API ID]
-+
-<1> API name and API instance version.
-<2> API ID.
-+
+
+[calloutlist]
+. API name and API instance version.
+. API ID.
+
+[start=3]
 . Retrieve from Kubernetes the name of the service with which you want to bind the API:
 +
 `kubectl get svc -n <namespace>`
@@ -81,9 +83,10 @@ After you bind your API, the API in API Manager is marked as Active. You are now
 +
 .The diagram shows the location where the status of the service is displayed.
 image::api-manager-status-for-service-mesh.png[95%, 95%]
-+
-<1> API name and API instance version.
-<2> Service status.
+
+[calloutlist]
+. API name and API instance version.
+. Service status.
 
 [[bind_using_ASM]]
 == Bind an API Created Using Anypoint Service Mesh

--- a/modules/ROOT/pages/common-commands-troubleshoot.adoc
+++ b/modules/ROOT/pages/common-commands-troubleshoot.adoc
@@ -39,7 +39,7 @@ To display information about the adapter pods:
 [[retrieve-policies-and-contracts-info]]
 == Retrieve Policies and Contracts Information from the Adapter
 
-When troubleshooting issues with Anypoint Service Mesh, you might need to retrieve policies and contracts details. To retrieve the details, obtain an Anypoint Serviesh Mesh management dump file: 
+When troubleshooting issues with Anypoint Service Mesh, you might need to retrieve policies and contracts details. To retrieve the details, obtain an Anypoint Service Mesh management dump file: 
 +
 `$ asmctl management dump`
 +
@@ -67,7 +67,7 @@ Because the `log4j` configuration file checks for changes every 60 seconds, you 
 
 When troubleshooting Anypoint Service Mesh, you might need to update the license:
 
-. Update the existing licence with one that you know is valid:
+. Update the existing license with one that you know is valid:
 +
 `$ asmctl management config license --license=/path/to/license.lic`
 . Redeploy the adapter:

--- a/modules/ROOT/pages/manage-apis-with-service-mesh.adoc
+++ b/modules/ROOT/pages/manage-apis-with-service-mesh.adoc
@@ -23,10 +23,12 @@ To apply policies:
 +
 .The diagram shows how to apply a policy to your API.
 image::select-policies-for-service-mesh.png[Applying Policies to APIs]
-+
-<1> The page where you specify a policy for your API is displayed.
-<2> Select a policy to apply.
-+
+
+[calloutlist]
+. The page where you specify a policy for your API is displayed.
+. Select a policy to apply.
+
+[start=3]
 . Select any of the following policies to secure your APIs: 
 * *Client ID Enforcement* 
 * *JWT Validation* 
@@ -40,9 +42,10 @@ NOTE: For the OpenID Connect OAuth 2.0 Token Enforcement policy, you must have c
 +
 .The diagram shows how to apply the Client ID Based Policy.
 image::apply-client-enforcement-policy-service-mesh.png[Apply Client ID Based Policy]
-+
-<1> The name of the policy is displayed at the top of the policy page.
-<2> Specify the origin of the client credentials.
+
+[calloutlist]
+. The name of the policy is displayed at the top of the policy page.
+. Specify the origin of the client credentials.
 
 For more information about how to apply policies, see the specific policy documentation.
 

--- a/modules/ROOT/pages/troubleshoot-adapter-provisioning-issues.adoc
+++ b/modules/ROOT/pages/troubleshoot-adapter-provisioning-issues.adoc
@@ -64,7 +64,7 @@ image::allocated-resources-adapter-prov-issues-service-mesh.png[Insufficient res
 
 To resolve this issue:
 
-. Delete the exisiting adapter.
+. Delete the existing adapter.
 . Assign additional resources to your Kubernetes Cluster, as required.
 . Provision your adapter again.
 
@@ -106,7 +106,7 @@ To resolve this issue:
 `$ kubectl -n service-mesh get cm service-mesh-registry-credentials-rotator-env -ogo-template='PLATFORM_URI:{{.data.PLATFORM_URI}}'`
 
 [[mule-fails-due-to-license-issues]]
-== Mule Runtime Engine Fails to Start Due to Licence Issues
+== Mule Runtime Engine Fails to Start Due to License Issues
 
 When you attempt to list your adapters, you might receive a `Failed` status.
 
@@ -183,6 +183,3 @@ If there are bindings associated with the adapter or the service instance, the s
 To resolve this issue, delete all the bindings associated with the adapter. When every binding is successfully deleted, the adapter is also deleted. 
 
 For more information, see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/service-catalog#instance-has-remaining-bindings[Kubernetes] help. 
-
-
-

--- a/modules/ROOT/pages/troubleshoot-installation-issues.adoc
+++ b/modules/ROOT/pages/troubleshoot-installation-issues.adoc
@@ -11,7 +11,7 @@ When you begin installing Anypoint Service Mesh, you might encounter issues caus
 * <<insufficient-pod-allocation,Insufficient pod allocation>>
 * <<service-mesh-not-found, Service Mesh not found>>
 * <<failed-webhook-calling,Installation failed due to WebHook calling error>>
-* <<installation-failed-unkown-reason, Installation failed due to unknown reason>>
+* <<installation-failed-unknown-reason, Installation failed due to unknown reason>>
 
 [[credentials-no-permissions]]
 == Credentials Do Not Have the Necessary Permissions or Entitlements
@@ -85,7 +85,7 @@ In the `Events` section, the result of the command shows that the scheduling of 
 `kubectl describe nodes`
 . Increase the capacity of the node or add nodes.
 +
-*Tip:* If you are using Aamzon EKS, this node capacity is calculated from the instance type. Therefore if you increase the instance type, the number of pods is increased.
+*Tip:* If you are using Amazon EKS, this node capacity is calculated from the instance type. Therefore if you increase the instance type, the number of pods is increased.
 . Restart the Anypoint Service Mesh installer to complete the installation.
 
 [[service-mesh-not-found]]
@@ -140,7 +140,7 @@ To resolve this issue:
 * `$ kubectl delete ns service-mesh`
 * `$ kubectl get clusterservicebrokers,clusterrole,psp,clusterrolebinding,mutatingwebhookconfigurations,validatingwebhookconfigurations -oname | awk '/(service-mesh|istio|catalog)/' | xargs kubectl delete`
 
-[[installation-failed-unkown-reason]]
+[[installation-failed-unknown-reason]]
 == Installation Failed Due to Unknown Reasons
 
 Your installation might fail due to an unknown error.

--- a/modules/ROOT/pages/troubleshoot-policy-enforcement-issues.adoc
+++ b/modules/ROOT/pages/troubleshoot-policy-enforcement-issues.adoc
@@ -192,7 +192,7 @@ image::internal-500-error-msg-service-mesh.png[Internal 500 error message]
 
 To resolve this issue: 
 
-. Replace the existing licence with a valid one:
+. Replace the existing license with a valid one:
 +
 `$ asmctl management config license --license=/path/to/license.lic`
 


### PR DESCRIPTION
ref: W-11732939

this PR provides a number of fixes/workarounds to reduce the number of build warnings and errors.

- use the new [calloutlist syntax](https://confluence.internal.salesforce.com/display/MTDT/Create+Desktop+Screenshots+for+MuleSoft+Docs#CreateDesktopScreenshotsforMuleSoftDocs-describe-annotationsDescribingAnnotatedScreenshots) for screenshot annotations
- fix a number of typos (some typos are in the image names too)

validated by creating a local build, and then go through every single page that was updated in this PR to validate that the numbers/layout for image annotations are matching exactly how it currently looks like docs.mulesoft.com.