### PR TITLE
[W-16553875] Update CODEOWNERS GUS path to prevent archiving of repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @priyaayyar @mulesoft/team-docs
+#GUSINFO:MS CX Engineering,MS CX (DOCS)
+* @glenn-rodgers-sf @mulesoft/team-docs


### PR DESCRIPTION
This repo was archived because of the lack of changes on the default branch this past year. It looks like adding a valid GUS path may prevent this from happening again. Also, changing the default owner to Glenn to reflect recent org changes.